### PR TITLE
Allow zero indentation

### DIFF
--- a/AStyle/src/astyle_main.cpp
+++ b/AStyle/src/astyle_main.cpp
@@ -3273,7 +3273,7 @@ void ASOptions::parseOption(const std::string& arg, const std::string& errorInfo
 		std::string spaceNumParam = getParam(arg, "t", "indent=tab=");
 		if (spaceNumParam.length() > 0)
 			spaceNum = atoi(spaceNumParam.c_str());
-		if (spaceNum < 2 || spaceNum > 20)
+		if (spaceNum > 20)
 			isOptionError(arg, errorInfo);
 		else
 		{
@@ -3324,7 +3324,7 @@ void ASOptions::parseOption(const std::string& arg, const std::string& errorInfo
 		std::string spaceNumParam = getParam(arg, "s", "indent=spaces=");
 		if (spaceNumParam.length() > 0)
 			spaceNum = atoi(spaceNumParam.c_str());
-		if (spaceNum < 2 || spaceNum > 20)
+		if (spaceNum > 20)
 			isOptionError(arg, errorInfo);
 		else
 		{


### PR DESCRIPTION
Its a no brainer and the quickest way to get rid of whitespace since this tool is indespensable anyway

I was wrestling all day with bindiff files with unreadable trailing space. I just need things like this to work